### PR TITLE
Disable Nagle

### DIFF
--- a/src/Transport/ClientAsync.cpp
+++ b/src/Transport/ClientAsync.cpp
@@ -16,7 +16,7 @@ ClientAsync::ClientAsync()
 : client()
 , availableData(0)
 , bufData(nullptr) {
-  client.setNoDelay(true);
+  // empty
 }
 
 bool ClientAsync::connect(IPAddress ip, uint16_t port) {

--- a/src/Transport/ClientSecureSync.cpp
+++ b/src/Transport/ClientSecureSync.cpp
@@ -20,10 +20,14 @@ ClientSecureSync::ClientSecureSync()
 
 bool ClientSecureSync::connect(IPAddress ip, uint16_t port) {
   bool ret = client.connect(ip, port);  // implicit conversion of return code int --> bool
-  // Set TCP option directly to bypass lack of working setNoDelay for WiFiClientSecure
   if (ret) {
+    #if defined(ARDUINO_ARCH_ESP8266)
+    client.setNoDelay(true);
+    #elif defined(ARDUINO_ARCH_ESP32)
+    // Set TCP option directly to bypass lack of working setNoDelay for WiFiClientSecure
     int val = true;
     client.setSocketOption(IPPROTO_TCP, TCP_NODELAY, &val, sizeof(int));
+    #endif
   }
   return ret;
 }

--- a/src/Transport/ClientSecureSync.cpp
+++ b/src/Transport/ClientSecureSync.cpp
@@ -19,13 +19,15 @@ ClientSecureSync::ClientSecureSync()
 
 bool ClientSecureSync::connect(IPAddress ip, uint16_t port) {
   bool ret = client.connect(ip, port);  // implicit conversion of return code int --> bool
-  client.setNoDelay(true);
+  //client.setNoDelay(true);
+  client.setSocketOption(IPPROTO_TCP, TCP_NODELAY, (const void*)true, sizeof(int));
   return ret;
 }
 
 bool ClientSecureSync::connect(const char* host, uint16_t port) {
   bool ret = client.connect(host, port);  // implicit conversion of return code int --> bool
-  client.setNoDelay(true);
+  //client.setNoDelay(true);
+  client.setSocketOption(IPPROTO_TCP, TCP_NODELAY, (const void*)true, sizeof(int));
   return ret;
 }
 

--- a/src/Transport/ClientSecureSync.cpp
+++ b/src/Transport/ClientSecureSync.cpp
@@ -9,6 +9,7 @@ the LICENSE file.
 #if defined(ARDUINO_ARCH_ESP8266) || defined(ARDUINO_ARCH_ESP32)
 
 #include "ClientSecureSync.h"
+#include <lwip/sockets.h>  // socket options
 
 namespace espMqttClientInternals {
 
@@ -19,15 +20,19 @@ ClientSecureSync::ClientSecureSync()
 
 bool ClientSecureSync::connect(IPAddress ip, uint16_t port) {
   bool ret = client.connect(ip, port);  // implicit conversion of return code int --> bool
+  // Set TCP option directly to bypass lack of working sztNoDelay for WiFiClientSecure
   // client.setNoDelay(true);
-  client.setSocketOption(IPPROTO_TCP, TCP_NODELAY, (const void*)true, sizeof(int));
+  int val = true;
+  client.setSocketOption(IPPROTO_TCP, TCP_NODELAY, (const void*)&val, sizeof(int));
   return ret;
 }
 
 bool ClientSecureSync::connect(const char* host, uint16_t port) {
   bool ret = client.connect(host, port);  // implicit conversion of return code int --> bool
+  // Set TCP option directly to bypass lack of working setNoDelay for WiFiClientSecure
   // client.setNoDelay(true);
-  client.setSocketOption(IPPROTO_TCP, TCP_NODELAY, (const void*)true, sizeof(int));
+  int val = true;
+  client.setSocketOption(IPPROTO_TCP, TCP_NODELAY, (const void*)&val, sizeof(int));
   return ret;
 }
 

--- a/src/Transport/ClientSecureSync.cpp
+++ b/src/Transport/ClientSecureSync.cpp
@@ -34,10 +34,14 @@ bool ClientSecureSync::connect(IPAddress ip, uint16_t port) {
 
 bool ClientSecureSync::connect(const char* host, uint16_t port) {
   bool ret = client.connect(host, port);  // implicit conversion of return code int --> bool
-  // Set TCP option directly to bypass lack of working setNoDelay for WiFiClientSecure
   if (ret) {
+    #if defined(ARDUINO_ARCH_ESP8266)
+    client.setNoDelay(true);
+    #elif defined(ARDUINO_ARCH_ESP32)
+    // Set TCP option directly to bypass lack of working setNoDelay for WiFiClientSecure
     int val = true;
     client.setSocketOption(IPPROTO_TCP, TCP_NODELAY, &val, sizeof(int));
+    #endif
   }
   return ret;
 }

--- a/src/Transport/ClientSecureSync.cpp
+++ b/src/Transport/ClientSecureSync.cpp
@@ -21,18 +21,24 @@ ClientSecureSync::ClientSecureSync()
 bool ClientSecureSync::connect(IPAddress ip, uint16_t port) {
   bool ret = client.connect(ip, port);  // implicit conversion of return code int --> bool
   // Set TCP option directly to bypass lack of working sztNoDelay for WiFiClientSecure
-  // client.setNoDelay(true);
-  int val = true;
-  client.setSocketOption(IPPROTO_TCP, TCP_NODELAY, (const void*)&val, sizeof(int));
+  #if defined(ARDUINO_ARCH_ESP8266)
+    client.setNoDelay(true);
+  #elif defined(ARDUINO_ARCH_ESP32)
+    int val = true;
+    client.setSocketOption(IPPROTO_TCP, TCP_NODELAY, &val, sizeof(int));
+  #endif
   return ret;
 }
 
 bool ClientSecureSync::connect(const char* host, uint16_t port) {
   bool ret = client.connect(host, port);  // implicit conversion of return code int --> bool
   // Set TCP option directly to bypass lack of working setNoDelay for WiFiClientSecure
-  // client.setNoDelay(true);
-  int val = true;
-  client.setSocketOption(IPPROTO_TCP, TCP_NODELAY, (const void*)&val, sizeof(int));
+  #if defined(ARDUINO_ARCH_ESP8266)
+    client.setNoDelay(true);
+  #elif defined(ARDUINO_ARCH_ESP32)
+    int val = true;
+    client.setSocketOption(IPPROTO_TCP, TCP_NODELAY, &val, sizeof(int));
+  #endif
   return ret;
 }
 

--- a/src/Transport/ClientSecureSync.cpp
+++ b/src/Transport/ClientSecureSync.cpp
@@ -20,25 +20,21 @@ ClientSecureSync::ClientSecureSync()
 
 bool ClientSecureSync::connect(IPAddress ip, uint16_t port) {
   bool ret = client.connect(ip, port);  // implicit conversion of return code int --> bool
-  // Set TCP option directly to bypass lack of working sztNoDelay for WiFiClientSecure
-  #if defined(ARDUINO_ARCH_ESP8266)
-    client.setNoDelay(true);
-  #elif defined(ARDUINO_ARCH_ESP32)
+  // Set TCP option directly to bypass lack of working setNoDelay for WiFiClientSecure
+  if (ret) {
     int val = true;
     client.setSocketOption(IPPROTO_TCP, TCP_NODELAY, &val, sizeof(int));
-  #endif
+  }
   return ret;
 }
 
 bool ClientSecureSync::connect(const char* host, uint16_t port) {
   bool ret = client.connect(host, port);  // implicit conversion of return code int --> bool
   // Set TCP option directly to bypass lack of working setNoDelay for WiFiClientSecure
-  #if defined(ARDUINO_ARCH_ESP8266)
-    client.setNoDelay(true);
-  #elif defined(ARDUINO_ARCH_ESP32)
+  if (ret) {
     int val = true;
     client.setSocketOption(IPPROTO_TCP, TCP_NODELAY, &val, sizeof(int));
-  #endif
+  }
   return ret;
 }
 

--- a/src/Transport/ClientSecureSync.cpp
+++ b/src/Transport/ClientSecureSync.cpp
@@ -19,14 +19,14 @@ ClientSecureSync::ClientSecureSync()
 
 bool ClientSecureSync::connect(IPAddress ip, uint16_t port) {
   bool ret = client.connect(ip, port);  // implicit conversion of return code int --> bool
-  //client.setNoDelay(true);
+  // client.setNoDelay(true);
   client.setSocketOption(IPPROTO_TCP, TCP_NODELAY, (const void*)true, sizeof(int));
   return ret;
 }
 
 bool ClientSecureSync::connect(const char* host, uint16_t port) {
   bool ret = client.connect(host, port);  // implicit conversion of return code int --> bool
-  //client.setNoDelay(true);
+  // client.setNoDelay(true);
   client.setSocketOption(IPPROTO_TCP, TCP_NODELAY, (const void*)true, sizeof(int));
   return ret;
 }

--- a/src/Transport/ClientSync.cpp
+++ b/src/Transport/ClientSync.cpp
@@ -9,6 +9,7 @@ the LICENSE file.
 #if defined(ARDUINO_ARCH_ESP8266) || defined(ARDUINO_ARCH_ESP32)
 
 #include "ClientSync.h"
+#include <lwip/sockets.h>  // socket options
 
 namespace espMqttClientInternals {
 
@@ -19,10 +20,14 @@ ClientSync::ClientSync()
 
 bool ClientSync::connect(IPAddress ip, uint16_t port) {
   bool ret = client.connect(ip, port);  // implicit conversion of return code int --> bool
-  // Set TCP option directly to bypass lack of working setNoDelay for WiFiClientSecure (consistency)
   if (ret) {
+    #if defined(ARDUINO_ARCH_ESP8266)
+    client.setNoDelay(true);
+    #elif defined(ARDUINO_ARCH_ESP32)
+    // Set TCP option directly to bypass lack of working setNoDelay for WiFiClientSecure (for consistency also here)
     int val = true;
     client.setSocketOption(IPPROTO_TCP, TCP_NODELAY, &val, sizeof(int));
+    #endif
   }
   return ret;
 }

--- a/src/Transport/ClientSync.cpp
+++ b/src/Transport/ClientSync.cpp
@@ -19,13 +19,21 @@ ClientSync::ClientSync()
 
 bool ClientSync::connect(IPAddress ip, uint16_t port) {
   bool ret = client.connect(ip, port);  // implicit conversion of return code int --> bool
-  client.setNoDelay(true);
+  // Set TCP option directly to bypass lack of working setNoDelay for WiFiClientSecure (consistency)
+  if (ret) {
+    int val = true;
+    client.setSocketOption(IPPROTO_TCP, TCP_NODELAY, &val, sizeof(int));
+  }
   return ret;
 }
 
 bool ClientSync::connect(const char* host, uint16_t port) {
   bool ret = client.connect(host, port);  // implicit conversion of return code int --> bool
-  client.setNoDelay(true);
+  // Set TCP option directly to bypass lack of working setNoDelay for WiFiClientSecure (consistency)
+  if (ret) {
+    int val = true;
+    client.setSocketOption(IPPROTO_TCP, TCP_NODELAY, &val, sizeof(int));
+  }
   return ret;
 }
 

--- a/src/Transport/ClientSync.cpp
+++ b/src/Transport/ClientSync.cpp
@@ -34,10 +34,14 @@ bool ClientSync::connect(IPAddress ip, uint16_t port) {
 
 bool ClientSync::connect(const char* host, uint16_t port) {
   bool ret = client.connect(host, port);  // implicit conversion of return code int --> bool
-  // Set TCP option directly to bypass lack of working setNoDelay for WiFiClientSecure (consistency)
   if (ret) {
+    #if defined(ARDUINO_ARCH_ESP8266)
+    client.setNoDelay(true);
+    #elif defined(ARDUINO_ARCH_ESP32)
+    // Set TCP option directly to bypass lack of working setNoDelay for WiFiClientSecure (for consistency also here)
     int val = true;
     client.setSocketOption(IPPROTO_TCP, TCP_NODELAY, &val, sizeof(int));
+    #endif
   }
   return ret;
 }

--- a/src/espMqttClientAsync.cpp
+++ b/src/espMqttClientAsync.cpp
@@ -38,7 +38,7 @@ void espMqttClientAsync::_setupClient(espMqttClientAsync* c) {
 }
 
 void espMqttClientAsync::onConnectCb(void* a, AsyncClient* c) {
-  (void)c;
+  c->setNoDelay(true);
   espMqttClientAsync* client = reinterpret_cast<espMqttClientAsync*>(a);
   client->_state = MqttClient::State::connectingTcp2;
   client->loop();


### PR DESCRIPTION
- workaround for broken WiFiClientSecure implementation
- postpone disabling Nagle until connection is made