### PR TITLE
Fix multithreaded logging

### DIFF
--- a/src/Logging.h
+++ b/src/Logging.h
@@ -14,9 +14,9 @@ the LICENSE file.
   #include "freertos/task.h"
   #if defined(DEBUG_ESP_MQTT_CLIENT)
   // Logging is en/disabled by Arduino framework macros
-    #define emc_log_i(...) vPortEnterCritical();log_i(__VA_ARGS__);vPortExitCritical()
-    #define emc_log_e(...) vPortEnterCritical();log_e(__VA_ARGS__);vPortExitCritical()
-    #define emc_log_w(...) vPortEnterCritical();log_w(__VA_ARGS__);vPortExitCritical()
+    #define emc_log_i(...) vPortEnterCritical(); log_i(__VA_ARGS__); vPortExitCritical()
+    #define emc_log_e(...) vPortEnterCritical(); log_e(__VA_ARGS__); vPortExitCritical()
+    #define emc_log_w(...) vPortEnterCritical(); log_w(__VA_ARGS__); vPortExitCritical()
   #else
   // Logging is disabled
     #define emc_log_i(...)

--- a/src/Logging.h
+++ b/src/Logging.h
@@ -10,11 +10,13 @@ the LICENSE file.
 
 #if defined(ARDUINO_ARCH_ESP32)
   #include <esp32-hal-log.h>
+  #include "freertos/FreeRTOS.h"
+  #include "freertos/task.h"
   #if defined(DEBUG_ESP_MQTT_CLIENT)
   // Logging is en/disabled by Arduino framework macros
-    #define emc_log_i(...) log_i(__VA_ARGS__)
-    #define emc_log_e(...) log_e(__VA_ARGS__)
-    #define emc_log_w(...) log_w(__VA_ARGS__)
+    #define emc_log_i(...) vPortEnterCritical();log_i(__VA_ARGS__);vPortExitCritical()
+    #define emc_log_e(...) vPortEnterCritical();log_e(__VA_ARGS__);vPortExitCritical()
+    #define emc_log_w(...) vPortEnterCritical();log_w(__VA_ARGS__);vPortExitCritical()
   #else
   // Logging is disabled
     #define emc_log_i(...)


### PR DESCRIPTION
When logging from multiple threads, the output can get mixed and mangled very easily.

This should prevent context switching while logging.

It obviously has a performance hit, but debug logging should be disabled when building for "production".