### PR TITLE
improved memory by no coping packet

### DIFF
--- a/src/Packets/Parser.cpp
+++ b/src/Packets/Parser.cpp
@@ -57,8 +57,8 @@ ParserResult Parser::parse(const uint8_t* data, size_t len, size_t* bytesRead) {
   return result;
 }
 
-const IncomingPacket& Parser::getPacket() const {
-  return _packet;
+const IncomingPacket* Parser::getPacket() {
+  return &_packet;
 }
 
 void Parser::reset() {

--- a/src/Packets/Parser.h
+++ b/src/Packets/Parser.h
@@ -64,7 +64,7 @@ class Parser {
  public:
   Parser();
   ParserResult parse(const uint8_t* data, size_t len, size_t* bytesRead);
-  const IncomingPacket& getPacket() const;
+  const IncomingPacket* getPacket();
   void reset();
 
  private:


### PR DESCRIPTION
in `MqttClient::_onPublish()` the `IncomingPacket` is unnecessarily copied.
Now the `Parser`-class returns a `const` pointer of the packet.