### PR TITLE
Fixed an error that prevented a successful reconnection.

### DIFF
--- a/src/MqttClient.cpp
+++ b/src/MqttClient.cpp
@@ -114,12 +114,12 @@ bool MqttClient::connect() {
                         _willPayloadLength,
                         (uint16_t)(_keepAlive / 1000),  // 32b to 16b doesn't overflow because it comes from 16b orignally
                         _clientId)) {
+      _state = State::connectingTcp1;
       #if defined(ARDUINO_ARCH_ESP32)
       if (_useInternalTask == espMqttClientTypes::UseInternalTask::YES) {
         vTaskResume(_taskHandle);
       }
       #endif
-      _state = State::connectingTcp1;
     } else {
       EMC_SEMAPHORE_GIVE();
       emc_log_e("Could not create CONNECT packet");


### PR DESCRIPTION
The state machine was started and immediately stopped again because the _state was set incorrectly when the state machine was started.