### PR TITLE
Update library.json: Point to ESPHome forks

### DIFF
--- a/.github/workflows/build_arduino-ide.yml
+++ b/.github/workflows/build_arduino-ide.yml
@@ -58,5 +58,5 @@ jobs:
           libraries: |
             - name: espMqttClient
               source-path: ./
-            - name: ESPAsyncTCP
+            - name: AsyncTCP
               source-url: https://github.com/me-no-dev/AsyncTCP.git

--- a/.github/workflows/build_platformio.yml
+++ b/.github/workflows/build_platformio.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install PlatformIO Core
         run: pip install --upgrade platformio
       - name: Download external libraries
-        run: pio pkg install --global --library me-no-dev/EspAsyncTCP
+        run: pio pkg install --global --library esphome/EspAsyncTCP-esphome
       - name: Build PlatformIO examples
         run: pio ci --lib="." --board=d1_mini
         env:
@@ -58,7 +58,7 @@ jobs:
       - name: Install PlatformIO Core
         run: pip install --upgrade platformio
       - name: Download external libraries
-        run: pio pkg install --global --library me-no-dev/AsyncTCP
+        run: pio pkg install --global --library esphome/AsyncTCP-esphome
       - name: Build PlatformIO examples
         run: pio ci --lib="." --board=lolin32
         env:

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Aims to be a non-blocking, fully compliant MQTT 3.1.1 client.
 - TCP and TCP/TLS using standard WiFiClient and WiFiClientSecure connections
 - Virtually unlimited incoming and outgoing payload sizes
 - Readable and understandable code
-- Fully async clients available via [AsyncTCP](https://github.com/me-no-dev/AsyncTCP) or [ESPAsnycTCP](https://github.com/me-no-dev/ESPAsyncTCP) (no TLS supported)
+- Fully async clients available via [AsyncTCP](https://github.com/esphome/AsyncTCP) or [ESPAsnycTCP](https://github.com/esphome/ESPAsyncTCP) (no TLS supported)
 - Supported platforms:
   - Espressif ESP8266 and ESP32 using the Arduino framework
   - Espressif ESP32 using the ESP IDF, see [esp idf component](https://docs.espressif.com/projects/arduino-esp32/en/latest/esp-idf_component.html)

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,7 +10,7 @@
 - TCP and TCP/TLS using standard WiFiClient and WiFiClientSecure connections
 - Virtually unlimited incoming and outgoing payload sizes
 - Readable and understandable code
-- Fully async clients available via [AsyncTCP](https://github.com/me-no-dev/AsyncTCP) or [ESPAsnycTCP](https://github.com/me-no-dev/ESPAsyncTCP) (no TLS supported)
+- Fully async clients available via [AsyncTCP](https://github.com/esphome/AsyncTCP) or [ESPAsnycTCP](https://github.com/esphome/ESPAsyncTCP) (no TLS supported)
 - Supported platforms:
   - Espressif ESP8266 and ESP32 using the Arduino framework
 - Basic Linux compatibility*. This includes WSL on Windows

--- a/library.json
+++ b/library.json
@@ -20,15 +20,15 @@
   "headers": ["espMqttClient.h", "espMqttClientAsync.h"],
   "dependencies": [
     {
-      "owner": "me-no-dev",
-      "name": "ESPAsyncTCP",
-      "version": ">=1.2.2",
+      "owner": "esphome",
+      "name": "ESPAsyncTCP-esphome",
+      "version": ">=2.0.0",
       "platforms": "espressif8266"
     },
     {
-      "owner": "me-no-dev",
-      "name": "AsyncTCP",
-      "version": ">=1.1.1",
+      "owner": "esphome",
+      "name": "AsyncTCP-esphome",
+      "version": ">=2.1.1",
       "platforms": "espressif32"
     }
   ],


### PR DESCRIPTION
Switch to AsyncTCP fork from ESPHome which will support ipv6 and also allows to configure the async+http task stack size with CONFIG_ASYNC_TCP_STACK_SIZE