### PR TITLE
fix compile error when EMC_MULTIPLE_CALLBACKS 1

### DIFF
--- a/src/MqttClientSetup.h
+++ b/src/MqttClientSetup.h
@@ -11,12 +11,12 @@ the LICENSE file.
 
 #pragma once
 
+#include "MqttClient.h"
+
 #if EMC_MULTIPLE_CALLBACKS
 #include <list>
 #include <utility>
 #endif
-
-#include "MqttClient.h"
 
 template <typename T>
 class MqttClientSetup : public MqttClient {


### PR DESCRIPTION
Simple fix to `#include <list>` when using multiple callbacks with EMC_MULTIPLE_CALLBACKS set to 1