### PR TITLE
fix(Outbox): re-anchor it._prev after _remove() to prevent dangling pointer

### DIFF
--- a/.github/workflows/test_platformio.yml
+++ b/.github/workflows/test_platformio.yml
@@ -25,3 +25,14 @@ jobs:
       - name: Test
         run: |
           pio test -e native -v
+
+  test-no_mempool:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
+    runs-on: ubuntu-latest
+    container: ghcr.io/bertmelis/pio-test-container
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Test
+        run: |
+          pio test -e native-no_mempool -v -f test_outbox

--- a/platformio.ini
+++ b/platformio.ini
@@ -41,3 +41,20 @@ test_testing_command =
   --track-origins=yes
   --error-exitcode=1
   ${platformio.build_dir}/${this.__env__}/program
+
+[env:native-no_mempool]
+platform = native
+test_build_src = yes
+build_flags =
+  ${common.build_flags}
+  -lgcov
+  --coverage
+;extra_scripts = test-coverage.py
+build_type = debug
+test_testing_command =
+  valgrind
+  --leak-check=full
+  --show-leak-kinds=all
+  --track-origins=yes
+  --error-exitcode=1
+  ${platformio.build_dir}/${this.__env__}/program

--- a/src/Outbox.h
+++ b/src/Outbox.h
@@ -150,12 +150,15 @@ class Outbox {
 
   // remove node at iterator, iterator points to next
   void remove(Iterator& it) {  // NOLINT(runtime/references)
-    if (!it) return;
+      if (!it) return;
     Node* node = it._node;
     Node* prev = it._prev;
-    ++it;
+    Node* next = node->next;
+
     _remove(prev, node);
-    it._prev = prev;  // re-anchor to live predecessor after node removal
+
+    it._prev = prev;
+    it._node = next;
   }
 
   // remove current node, current points to next

--- a/src/Outbox.h
+++ b/src/Outbox.h
@@ -155,6 +155,7 @@ class Outbox {
     Node* prev = it._prev;
     ++it;
     _remove(prev, node);
+    it._prev = prev;  // re-anchor to live predecessor after node removal
   }
 
   // remove current node, current points to next

--- a/test/test_outbox/test_outbox.cpp
+++ b/test/test_outbox/test_outbox.cpp
@@ -159,6 +159,39 @@ void test_outbox_removeCurrent() {
   // Valgrind should not detect a leak here
 }
 
+
+// Regression test for Outbox::remove() dangling-prev bug.
+// root cause: ++it (inside remove()) stored it._prev = node, then _remove()
+// freed that node, leaving it._prev dangling. A second consecutive remove()
+// call then passed the freed pointer as 'prev' to _remove(), corrupting the
+// queue and any heap block recycled into that address.
+// fix: re-anchor it._prev = prev (the live predecessor) after _remove().
+void test_outbox_remove_consecutive() {
+  Outbox<uint32_t> outbox;
+  outbox.emplace(1);
+  outbox.emplace(2);
+  outbox.emplace(3);
+
+  Outbox<uint32_t>::Iterator it = outbox.front();
+  TEST_ASSERT_EQUAL_UINT32(1, *(it.get()));
+
+  // First remove: eliminates 1, it advances to 2.
+  // Without the fix, it._prev is now a dangling pointer to freed node 1.
+  outbox.remove(it);
+  TEST_ASSERT_NOT_NULL(it.get());
+  TEST_ASSERT_EQUAL_UINT32(2, *(it.get()));
+
+  // Second remove: without the fix, passes dangling it._prev to _remove()
+  // and writes through a freed pointer.  With the fix it._prev == nullptr
+  // (correct head predecessor after node 1 was removed).
+  outbox.remove(it);
+  TEST_ASSERT_NOT_NULL(it.get());
+  TEST_ASSERT_EQUAL_UINT32(3, *(it.get()));
+
+  outbox.remove(it);
+  TEST_ASSERT_NULL(it.get());
+  TEST_ASSERT_TRUE(outbox.empty());
+}
 int main() {
   UNITY_BEGIN();
   RUN_TEST(test_outbox_create);
@@ -167,5 +200,6 @@ int main() {
   RUN_TEST(test_outbox_remove1);
   RUN_TEST(test_outbox_remove2);
   RUN_TEST(test_outbox_removeCurrent);
+  RUN_TEST(test_outbox_remove_consecutive);
   return UNITY_END();
 }

--- a/test/test_outbox/test_outbox.cpp
+++ b/test/test_outbox/test_outbox.cpp
@@ -159,39 +159,25 @@ void test_outbox_removeCurrent() {
   // Valgrind should not detect a leak here
 }
 
-
-// Regression test for Outbox::remove() dangling-prev bug.
-// root cause: ++it (inside remove()) stored it._prev = node, then _remove()
-// freed that node, leaving it._prev dangling. A second consecutive remove()
-// call then passed the freed pointer as 'prev' to _remove(), corrupting the
-// queue and any heap block recycled into that address.
-// fix: re-anchor it._prev = prev (the live predecessor) after _remove().
 void test_outbox_remove_consecutive() {
   Outbox<uint32_t> outbox;
-  outbox.emplace(1);
-  outbox.emplace(2);
-  outbox.emplace(3);
+
+  for (uint32_t i = 1; i <= 5; i++) {
+    outbox.emplace(i);
+  }
+  TEST_ASSERT_EQUAL_UINT32(5, outbox.size());
 
   Outbox<uint32_t>::Iterator it = outbox.front();
-  TEST_ASSERT_EQUAL_UINT32(1, *(it.get()));
+  ++it; // 2
+  ++it; // 3
 
-  // First remove: eliminates 1, it advances to 2.
-  // Without the fix, it._prev is now a dangling pointer to freed node 1.
-  outbox.remove(it);
-  TEST_ASSERT_NOT_NULL(it.get());
-  TEST_ASSERT_EQUAL_UINT32(2, *(it.get()));
+  outbox.remove(it); // removes 3
+  outbox.remove(it);  // removes 4
 
-  // Second remove: without the fix, passes dangling it._prev to _remove()
-  // and writes through a freed pointer.  With the fix it._prev == nullptr
-  // (correct head predecessor after node 1 was removed).
-  outbox.remove(it);
-  TEST_ASSERT_NOT_NULL(it.get());
-  TEST_ASSERT_EQUAL_UINT32(3, *(it.get()));
-
-  outbox.remove(it);
-  TEST_ASSERT_NULL(it.get());
-  TEST_ASSERT_TRUE(outbox.empty());
+  TEST_ASSERT_EQUAL_UINT32(3, outbox.size());
 }
+
+
 int main() {
   UNITY_BEGIN();
   RUN_TEST(test_outbox_create);


### PR DESCRIPTION
## Problem

`remove(Iterator& it)` calls `++it` to advance the iterator *before* passing the predecessor pointer `prev` to `_remove()`. The `++it` operator sets `it._prev = node` (the node that `_remove` is about to free). After `_remove(prev, node)` deallocates `node`, `it._prev` holds a dangling pointer.

A second call to `remove(it)` extracts `prev = it._prev` (now dangling) and passes it to `_remove()`. Depending on which internal branch fires:

```cpp
_last = prev;            // writes to freed memory
_last->next = nullptr;   // dereferences freed memory
prev->next = node->next; // dereferences freed memory
```

This corrupts whatever heap block was recycled into that slot and produces use-after-free crashes in the caller. The failure surface is any code path that calls `_clearQueue(0)` on TCP disconnect while outbox items remain — exactly what happens on an unexpected TCP RST.

We observed five distinct crash signatures on an ESP32 fleet (three separate devices, confirmed single root cause): `LoadProhibited` faulting on `Packet::packetType` / `_data[0]`, a `heap_caps` assertion in `~Packet` freeing `_data`, two lwIP `tcp_input` assertions, and a `lwip_netconn_do_close_internal` `LoadProhibited` — all traceable to a single corrupted outbox node after a TCP RST disconnection.

## Fix

Capture all iterator state before the removal, then rebuild both fields explicitly — avoiding `++it` entirely (suggested by @bertmelis):

```cpp
  void remove(Iterator& it) {  // NOLINT(runtime/references)
    if (!it) return;
    Node* node = it._node;
    Node* prev = it._prev;
    Node* next = node->next;
    _remove(prev, node);
    it._prev = prev;
    it._node = next;
  }
```

`prev` is the live predecessor that `_remove` just used to relink the queue — it remains valid. `next` is captured before the removal so it is never read through the freed `node`.

## Test

Added `test_outbox_remove_consecutive` (improved by @bertmelis) which calls `remove(it)` twice in succession from the middle of a five-element outbox. Without the fix, the second call passes a dangling pointer to `_remove()`; with the fix the size is correct and no memory is corrupted.

The test suite is also run without the memory pool (`EMC_USE_MEMPOOL=0`) so Valgrind can detect use-after-free — with the pool enabled, recycled memory masks the UB.

## Validation

Validated on an 8-device ESP32 fleet: 9-hour soak after applying this patch, including 4 absorbed TCP RST events on one device during an extended 14-hour run, 0 post-patch coredumps across the full fleet.